### PR TITLE
bump version 0.0.4

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,25 +1,27 @@
 package:
     name: themis-ml
-    version: "0.0.2"
+    version: "0.0.4"
 
 source:
-    git_rev: v0.0.2
+    git_rev: v0.0.4
     git_url: https://github.com/cosmicBboy/themis-ml.git
 
 requirements:
   build:
     - python
     - setuptools
+    # - scipy
     - pandas
-    - numpy
+    # - numpy
     - pathlib2
-    - scikit-learn
+    - scikit-learn >=0.19.1
     - pytest
   run:
     - python
-    - numpy
+    # - scipy
+    # - numpy
     - pandas
-    - scikit-learn
+    - scikit-learn >=0.19.1
     - pathlib2
     - pytest
 


### PR DESCRIPTION
updates meta.yaml to handle numpy and scipy deps
automatically from sklearn